### PR TITLE
zshプラグインの形式に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ zplug "arks22/tmuximum", as:command
 antigen bundle arks22/tmuximum
 ```
 
+#### zgen users
+
+```
+zgen load yuki-ycino/tmuximum
+```
+
 #### Manually
 
 ```

--- a/tmuximum.plugin.zsh
+++ b/tmuximum.plugin.zsh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env zsh
 
 function tmuximum::help() {
   echo "tmuximum: Usage"
@@ -136,4 +136,6 @@ function main() {
   fi
 }
 
-main $@
+function tmuximum() {
+  main $@
+}

--- a/tmuximum.zsh
+++ b/tmuximum.zsh
@@ -1,0 +1,1 @@
+tmuximum.plugin.zsh


### PR DESCRIPTION
日本語で失礼します。

最近見るzshのプラグインは `{repository_name}.plugin.zsh` というファイルを配置し、プラグインマネージャがそのファイルを読み込む形式になっているように思います（フォーマットについてしっかりと調べたわけではないので間違えていたら申し訳ないです）。

自分はzgenを使っているのですが、zgenの動作は上記の `*.plugins.zsh` を読み込む形式になっているため、導入してもtmuximumコマンドが使えるようになりません。
PRの変更を加えて手元で試すとzgenでコマンドとして使えるようになりました。

コマンドを追加するzshプラグインについてzgenでいくつか導入しているのですが、それらでは `*,plugins.zsh` に関数として記述する。 `*.plugins.zsh` から `*.zsh` にシンボリックリンクを作成する。などをしているリポジトリが多いように思います。

おそらく、antigenやzplugでもその形式で読み込めると思うのですが、 `*.plugins.zsh` の形式に変更していただく事はできないでしょうか。