### PR TITLE
ウィンドウとセッションを終了する際に複数の選択を可能にした

### DIFF
--- a/tmuximum.plugin.zsh
+++ b/tmuximum.plugin.zsh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env zsh
 
 function tmuximum::help() {
   echo "tmuximum: Usage"
@@ -6,7 +6,7 @@ function tmuximum::help() {
   echo "OPTIONS : \"-h\" --> Display help message (this message)"
   echo "          \"-s\" --> Start kill-session mode"
   echo "          \"-w\" --> Start kill-window mode"
-  echo "To quit tmuximum, press esc" 
+  echo "To quit tmuximum, press esc"
 }
 
 function tmuximum::operation() {
@@ -43,12 +43,18 @@ function tmuximum::operation-list() {
 }
 
 function tmuximum::kill-session() {
-  answer=$(tmuximum::kill-session-list | "${filter[@]}")
+  if [[ $filter[1] == "fzf-tmux" ]] || [[ $filter[1] == "fzf" ]]; then
+    answer=$(tmuximum::kill-session-list | "${multi_filter[@]}")
+  else
+    answer=$(tmuximum::kill-session-list | "${filter[@]}")
+  fi
+
   case $answer in
     *kill*Server* ) tmux kill-server ; tmuximum::operation ;;
     *kill*windows* )
-      tmux kill-session -t $(echo "$answer" | awk '{print $4}' | sed "s/://g")
-      tmux has-session 2>/dev/null && tmuximum::kill-session || tmuximum::operation
+      echo $answer | while read -r session; do
+        tmux kill-session -t $(echo $session | awk '{print $4}' | sed "s/://g")
+      done
     ;;
   "back" ) tmuximum::operation
   esac
@@ -66,9 +72,16 @@ function tmuximum::kill-session-list() {
 
 function tmuximum::kill-window() {
   if (( $(tmux display-message -p '#{session_windows}') > 1 )); then
-    answer=$(tmuximum::kill-window-list | "${filter[@]}" )
+    if [[ $filter[1] == "fzf-tmux" ]] || [[ $filter[1] == "fzf" ]]; then
+      answer=$(tmuximum::kill-window-list | "${multi_filter[@]}")
+    else
+      answer=$(tmuximum::kill-window-list | "${filter[@]}")
+    fi
+
     if [[ "$answer" =~ "kill" ]]; then
-      tmux kill-window -t $(echo "$answer" | awk '{print $4}' | sed "s/://g")
+      echo $answer | while read -r window; do
+        tmux kill-window -t $(echo $window | awk '{print $4}' | sed "s/://g")
+      done
       tmuximum::kill-window
     elif [[ $answer = "back" ]]; then
       tmuximum::operation
@@ -107,8 +120,8 @@ function set-filter() {
   while [[ -n $filters ]]; do
   filter=${filters%%:*}
     if type "$filter" >/dev/null 2>&1; then
-      [[ "$filter" = "fzf" ]] && filter=($filter --ansi --prompt=tmuximum\ \>)
-      [[ "$filter" = "fzf-tmux" ]] && filter=($filter -r --ansi --prompt=tmuximum\ \>)
+      [[ "$filter" = "fzf" ]] && filter=($filter --ansi --prompt="tmuximum >") && multi_filter=($filter --multi --ansi --prompt="tmuximum >")
+      [[ "$filter" = "fzf-tmux" ]] && filter=($filter -r --ansi --prompt="tmuximum >") && multi_filter=($filter --multi --ansi --prompt="tmuximum >")
       return 0
     else
       filters="${filters#*:}"
@@ -136,4 +149,6 @@ function main() {
   fi
 }
 
-main $@
+function tmuximum() {
+  main $@
+}

--- a/tmuximum.zsh
+++ b/tmuximum.zsh
@@ -1,0 +1,1 @@
+tmuximum.plugin.zsh


### PR DESCRIPTION
kill windows と kill sessions を選択した際に、fzfとfzf-tmuxに `--multi` オプションを指定したものを使うようにし、各 kill コマンドに対してうまく値が渡るように変更しました。
pecoとpercolについても似たような変更で対応可能だと思いますが、手元の環境で検証しづらく、動作確認ができていません。

filter変数が配列で定義されており、展開時にダブルクォートが消えてしまうためオプションの文字列結合ではなく別の変数でfilterを定義しています。